### PR TITLE
Stop adding teor to every PR as a reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Automatically generated CODEOWNERS file.
-draft-irtf-cfrg-frost.md ckomlo@uwaterloo.ca iang@uwaterloo.ca teor@riseup.net
+draft-irtf-cfrg-frost.md ckomlo@uwaterloo.ca iang@uwaterloo.ca


### PR DESCRIPTION
This removes teor from the CODEOWNERS file, so I don't get added as a reviewer to every PR.